### PR TITLE
feat: support for hidden services

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ While Tor and I2P offer robust solutions for anonymous networking, their powerfu
 
 - [x] Exit nodes
 
-- [ ] Hidden services
+- [X] Hidden services
+
+- [ ] CLI
 
 ## Licensing
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/ipfs/boxo v0.30.0 // indirect
 	github.com/ipfs/go-log/v2 v2.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ipfs/boxo v0.30.0 h1:7afsoxPGGqfoH7Dum/wOTGUB9M5fb8HyKPMlLfBvIEQ=

--- a/p2p/onion/circuit_bind.go
+++ b/p2p/onion/circuit_bind.go
@@ -1,0 +1,44 @@
+package onion
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/RogueTeam/onion/p2p/onion/command"
+	"github.com/hashicorp/yamux"
+	"github.com/libp2p/go-libp2p/core/crypto"
+)
+
+// Binds a hidden service based on a private key
+func (c *Circuit) Bind(priv crypto.PrivKey) (session *yamux.Session, err error) {
+	rawPub, err := crypto.MarshalPublicKey(priv.GetPublic())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	rawPubHash := command.DefaultHashAlgorithm().Sum(rawPub)
+	rawSign, err := priv.Sign(rawPubHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
+	var bind = command.Command{
+		Action: command.ActionBind,
+		Data: command.Data{
+			Bind: &command.Bind{
+				PublicKey: hex.EncodeToString(rawPub),
+				Signature: hex.EncodeToString(rawSign),
+			},
+		},
+	}
+	err = bind.Send(c.Active, c.Settings[c.Current])
+	if err != nil {
+		return nil, fmt.Errorf("failed to send bind: %w", err)
+	}
+
+	session, err = yamux.Server(c.Active, yamux.DefaultConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to upgrade yamux: %w", err)
+	}
+	return session, nil
+}

--- a/p2p/onion/circuit_dial.go
+++ b/p2p/onion/circuit_dial.go
@@ -2,16 +2,45 @@ package onion
 
 import (
 	"fmt"
+	"io"
 
+	"github.com/RogueTeam/onion/p2p/identity"
 	"github.com/RogueTeam/onion/p2p/onion/command"
+	"github.com/RogueTeam/onion/utils"
 	"github.com/hashicorp/yamux"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/security/noise"
 )
+
+type HiddenServiceConnection struct {
+	Address peer.ID
+	Noise   *noise.Transport
+	Session *yamux.Session
+}
+
+func (h *HiddenServiceConnection) Close() (err error) {
+	return h.Session.Close()
+}
+
+func (h *HiddenServiceConnection) Open() (conn io.ReadWriteCloser, err error) {
+	insecure, err := h.Session.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open connection: %w", err)
+	}
+
+	ctx, _ := utils.NewContext()
+	conn, err = h.Noise.SecureOutbound(ctx, insecure, h.Address)
+	if err != nil {
+		return nil, fmt.Errorf("failed upgrade connection: %w", err)
+	}
+	return conn, nil
+}
 
 // Receives the DefaultHashAlgorithm of the public key of the hidden service and returns a yamux.Session
 // The yamux session can create multiple dials to the same address using the session.Open method.
 // The circuit should be constructed in order to force the last node be the one advertising the service.
 // If not, the connection will fail
-func (c *Circuit) Dial(address string) (session *yamux.Session, err error) {
+func (c *Circuit) Dial(address peer.ID) (hidden *HiddenServiceConnection, err error) {
 	var dial = command.Command{
 		Action: command.ActionDial,
 		Data: command.Data{
@@ -25,10 +54,31 @@ func (c *Circuit) Dial(address string) (session *yamux.Session, err error) {
 		return nil, fmt.Errorf("failed to send dial: %w", err)
 	}
 
-	session, err = yamux.Server(c.Active, yamux.DefaultConfig())
+	session, err := yamux.Server(c.Active, yamux.DefaultConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to negotiate connection: %w", err)
 	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		session.Close()
+	}()
 
-	return session, nil
+	hiddenIdentity, err := identity.NewKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate hidden identity: %w", err)
+	}
+
+	noiseTransport, err := noise.New(ProtocolId, hiddenIdentity, DefaultMuxerUpgrader)
+	if err != nil {
+		return nil, fmt.Errorf("failed upgrade noise transport: %w", err)
+	}
+
+	hidden = &HiddenServiceConnection{
+		Address: address,
+		Noise:   noiseTransport,
+		Session: session,
+	}
+	return hidden, nil
 }

--- a/p2p/onion/circuit_dial.go
+++ b/p2p/onion/circuit_dial.go
@@ -1,0 +1,34 @@
+package onion
+
+import (
+	"fmt"
+
+	"github.com/RogueTeam/onion/p2p/onion/command"
+	"github.com/hashicorp/yamux"
+)
+
+// Receives the DefaultHashAlgorithm of the public key of the hidden service and returns a yamux.Session
+// The yamux session can create multiple dials to the same address using the session.Open method.
+// The circuit should be constructed in order to force the last node be the one advertising the service.
+// If not, the connection will fail
+func (c *Circuit) Dial(address string) (session *yamux.Session, err error) {
+	var dial = command.Command{
+		Action: command.ActionDial,
+		Data: command.Data{
+			Dial: &command.Dial{
+				Address: address,
+			},
+		},
+	}
+	err = dial.Send(c.Active, c.Settings[c.Current])
+	if err != nil {
+		return nil, fmt.Errorf("failed to send dial: %w", err)
+	}
+
+	session, err = yamux.Server(c.Active, yamux.DefaultConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to negotiate connection: %w", err)
+	}
+
+	return session, nil
+}

--- a/p2p/onion/command/command.go
+++ b/p2p/onion/command/command.go
@@ -36,13 +36,13 @@ type (
 	}
 	Bind struct {
 		// Hex encoded public key
-		PublicKey string `json:"publicKey"`
+		HexPublicKey string `json:"publicKey"`
 		// Hex encoded signature of the DefaultHashAlgorithm of the public key
-		Signature string
+		HexSignature string
 	}
 	Dial struct {
 		// Address of the hidden service
-		Address string `json:"address"`
+		Address peer.ID `json:"address"`
 	}
 	Data struct {
 		Settings *Settings `msgpack:",omitempty"`

--- a/p2p/onion/command/command.go
+++ b/p2p/onion/command/command.go
@@ -34,11 +34,23 @@ type (
 	External struct {
 		Address multiaddr.Multiaddr `json:"address"`
 	}
+	Bind struct {
+		// Hex encoded public key
+		PublicKey string `json:"publicKey"`
+		// Hex encoded signature of the DefaultHashAlgorithm of the public key
+		Signature string
+	}
+	Dial struct {
+		// Address of the hidden service
+		Address string `json:"address"`
+	}
 	Data struct {
+		Settings *Settings `msgpack:",omitempty"`
 		Noise    *Noise    `msgpack:",omitempty"`
 		Extend   *Extend   `msgpack:",omitempty"`
 		External *External `msgpack:",omitempty"`
-		Settings *Settings `msgpack:",omitempty"`
+		Bind     *Bind     `msgpack:",omitempty"`
+		Dial     *Dial     `msgpack:",omitempty"`
 	}
 	Command struct {
 		Action   Action
@@ -60,6 +72,10 @@ const (
 	ActionExtend
 	// Connects to a remote service
 	ActionExternal
+	// Bind a hidden service
+	ActionBind
+	// Dials to a hidden service
+	ActionDial
 )
 
 func (a Action) String() (s string) {

--- a/p2p/onion/connection.go
+++ b/p2p/onion/connection.go
@@ -11,6 +11,7 @@ import (
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 )
 
@@ -38,7 +39,7 @@ type Connection struct {
 	// Used for identifying those peers that support External mode (Exit nodes)
 	ExternalMode bool
 	// Storage for hidden services
-	HiddenServices *utils.Map[string, *yamux.Session]
+	HiddenServices *utils.Map[peer.ID, *yamux.Session]
 }
 
 // Base logic for handling the connection

--- a/p2p/onion/connection.go
+++ b/p2p/onion/connection.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/RogueTeam/onion/p2p/log"
 	"github.com/RogueTeam/onion/p2p/onion/command"
+	"github.com/RogueTeam/onion/utils"
+	"github.com/hashicorp/yamux"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -35,6 +37,8 @@ type Connection struct {
 	Secured bool
 	// Used for identifying those peers that support External mode (Exit nodes)
 	ExternalMode bool
+	// Storage for hidden services
+	HiddenServices *utils.Map[string, *yamux.Session]
 }
 
 // Base logic for handling the connection
@@ -77,7 +81,16 @@ func (c *Connection) Handle() (err error) {
 			if err != nil {
 				return fmt.Errorf("failed to handle external: %w", err)
 			}
-			break
+		case command.ActionBind:
+			err = c.Bind(&cmd)
+			if err != nil {
+				return fmt.Errorf("failed to handle bind: %w", err)
+			}
+		case command.ActionDial:
+			err = c.Dial(&cmd)
+			if err != nil {
+				return fmt.Errorf("failed to handle bind: %w", err)
+			}
 		default:
 			return fmt.Errorf("unknown command: %s", cmd.Action.String())
 		}

--- a/p2p/onion/connection_bind.go
+++ b/p2p/onion/connection_bind.go
@@ -1,0 +1,80 @@
+package onion
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/RogueTeam/onion/p2p/onion/command"
+	"github.com/RogueTeam/onion/utils"
+	"github.com/hashicorp/yamux"
+	"github.com/libp2p/go-libp2p/core/crypto"
+)
+
+// Handle the bind of a hidden service
+func (c *Connection) Bind(cmd *command.Command) (err error) {
+	if !c.Secured {
+		return errors.New("connection not secured")
+	}
+	if cmd.Data.Bind == nil {
+		return errors.New("bind not passed")
+	}
+
+	// Prepare public key ==================================
+	rawPub, err := hex.DecodeString(cmd.Data.Bind.PublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to decode publickey: %w", err)
+	}
+
+	pub, err := crypto.UnmarshalPublicKey(rawPub)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal public key: %w", err)
+	}
+
+	rawHiddenAddress := command.DefaultHashAlgorithm().Sum(rawPub)
+
+	// Prepare signature ===================================
+	sig, err := hex.DecodeString(cmd.Data.Bind.Signature)
+	if err != nil {
+		return fmt.Errorf("failed to decode signature: %w", err)
+	}
+
+	// Validate signature ==================================
+	valid, err := pub.Verify(rawHiddenAddress, sig)
+	if err != nil {
+		return fmt.Errorf("failed to verify publickey signature: %w", err)
+	}
+
+	if !valid {
+		return errors.New("invalid signature")
+	}
+
+	ctx, cancel := utils.NewContext()
+	defer cancel()
+
+	cid, err := createCID(rawHiddenAddress)
+	if err != nil {
+		return fmt.Errorf("failed to create cid from pub hash: %w", err)
+	}
+
+	err = c.DHT.Provide(ctx, cid, true)
+	if err != nil {
+		return fmt.Errorf("failed to advertise cid: %w", err)
+	}
+
+	// Accept connections ==================================
+	session, err := yamux.Client(c.Conn, yamux.DefaultConfig())
+	if err != nil {
+		return fmt.Errorf("failed to upgrade to yamux: %w", err)
+	}
+	defer session.Close()
+
+	pubHash := hex.EncodeToString(rawHiddenAddress)
+	c.HiddenServices.Store(pubHash, session)
+	defer c.HiddenServices.Delete(pubHash)
+
+	// Wait until caller closes. This will prevent corruption of the pipeline
+	<-session.CloseChan()
+
+	return nil
+}

--- a/p2p/onion/connection_dial.go
+++ b/p2p/onion/connection_dial.go
@@ -1,0 +1,49 @@
+package onion
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/RogueTeam/onion/p2p/onion/command"
+	"github.com/hashicorp/yamux"
+)
+
+// Dial to a hidden service hosted by the machine
+func (c *Connection) Dial(cmd *command.Command) (err error) {
+	if !c.Secured {
+		return errors.New("connection not secured")
+	}
+	if cmd.Data.Dial == nil {
+		return errors.New("dial not passed")
+	}
+
+	svcSession, found := c.HiddenServices.Load(cmd.Data.Dial.Address)
+	if !found {
+		return errors.New("service not hosted by this node")
+	}
+
+	clientSession, err := yamux.Client(c.Conn, yamux.DefaultConfig())
+	if err != nil {
+		return fmt.Errorf("failed to upgrade client conn: %w", err)
+	}
+	defer clientSession.Close()
+
+	for {
+		clientConn, err := clientSession.Accept()
+		if err != nil {
+			return fmt.Errorf("failed to accept client connection: %w", err)
+		}
+
+		serviceConn, err := svcSession.Open()
+		if err != nil {
+			return fmt.Errorf("failed to open new connection: %w", err)
+		}
+
+		go func() {
+			defer serviceConn.Close()
+			go io.Copy(clientConn, serviceConn)
+			io.Copy(serviceConn, clientConn)
+		}()
+	}
+}

--- a/p2p/onion/peers.go
+++ b/p2p/onion/peers.go
@@ -15,16 +15,20 @@ type Peer struct {
 }
 
 // Determines which Nodes in the network is serving a specific hidden address
-func (s *Service) Where(addr string) (peers []peer.AddrInfo, err error) {
+func (s *Service) Where(addr peer.ID) (peers []peer.AddrInfo, err error) {
+	ctx, cancel := utils.NewContext()
+	defer cancel()
+
+	cid, err := createCID(addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to crearte CID: %w", err)
+	}
+
+	peers, err = s.DHT.FindProviders(ctx, cid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find providers for cid: %w", err)
+	}
 	return peers, nil
-	// ctx, cancel := utils.NewContext()
-	// defer cancel()
-	//
-	// peers, err = s.DHT.FindProviders(ctx, cid)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("failed to find providers for cid: %w", err)
-	// }
-	// return peers, nil
 }
 
 // Lists peers compatible to the onion network.

--- a/p2p/onion/peers.go
+++ b/p2p/onion/peers.go
@@ -14,6 +14,19 @@ type Peer struct {
 	Modes set.Set[cid.Cid]
 }
 
+// Determines which Nodes in the network is serving a specific hidden address
+func (s *Service) Where(addr string) (peers []peer.AddrInfo, err error) {
+	return peers, nil
+	// ctx, cancel := utils.NewContext()
+	// defer cancel()
+	//
+	// peers, err = s.DHT.FindProviders(ctx, cid)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to find providers for cid: %w", err)
+	// }
+	// return peers, nil
+}
+
 // Lists peers compatible to the onion network.
 // This function is useful with some filtering from your part.
 // It returns a raw list of the peers using the onion protocol.

--- a/p2p/onion/stream_handler.go
+++ b/p2p/onion/stream_handler.go
@@ -19,9 +19,10 @@ func (s *Service) StreamHandler(stream network.Stream) {
 		Logger: log.Logger{
 			PeerID: stream.Conn().RemotePeer(),
 		},
-		Noise:        s.Noise,
-		Secured:      false,
-		ExternalMode: s.Settings.OutsideMode,
+		Noise:          s.Noise,
+		Secured:        false,
+		ExternalMode:   s.Settings.OutsideMode,
+		HiddenServices: s.HiddenServices,
 	}
 	err := conn.Handle()
 	if err != nil {

--- a/utils/context.go
+++ b/utils/context.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const DefaultTimeout = 5 * time.Second
+const DefaultTimeout = 5 * time.Minute
 
 func NewContext() (ctx context.Context, cancel func()) {
 	return NewContextWithTimeout(DefaultTimeout)

--- a/utils/map.go
+++ b/utils/map.go
@@ -1,0 +1,16 @@
+package utils
+
+import "sync"
+
+type Map[K, T any] struct {
+	sync.Map
+}
+
+func (m *Map[K, T]) Load(k K) (v T, found bool) {
+	rawV, found := m.Map.Load(k)
+	return rawV.(T), found
+}
+
+func (m *Map[K, T]) Store(k K, v T) {
+	m.Map.Store(k, v)
+}


### PR DESCRIPTION
# Main changes

- Added support for hidden services
- Added abstraction to similar to `net.Listener` in order to open a circuit and create a hidden service from it.
- Added an abstraction to open multiple streams against a single hidden service connection.

## Workaround

### What is a hidden service?

A hidden service allows a network participant to expose a network service without revealing its public address and without the need of a public IP.

### How it works?

#### Binding side

1. A network user will construct a circuit intended to advertise its hidden service. Using as how many intermediate nodes he decides.
2. Once the circuit its constructed, the network user will create a libp2p's peer identity used for identifying the hidden service.
3. The network user passes the public key plus its signature to the last node on the circuit.
4. Circuit noden, broadcast the hidden service address which is the same as the `peer.ID` obtained from the public key.
5. Incoming connections will be forwarded thought the YAMUX session opened by the Hidden service author.

#### Connecting side

1. Client queries the DHT requesting for those nodes serving the hidden service. It then receives the `AddrInfo`s for the peers available.
2. Client construct a Circuit to any of the provided peers.
3. Once the circuit is ready. Client Upgrades the Connection using the `Dial` Action.
4. Circuit node check if the service requested was binding with it, if not connection is closed.
5. If connection exists. A new YAMUX is opened both sides. Forwarding traffic between both.
6. **Hidden service verification is done directly by the client, client opens a noise channel expecting the other peer be the same as the address requested**
